### PR TITLE
Update OpenSSL-Universal version

### DIFF
--- a/VerifyStoreReceipt.podspec
+++ b/VerifyStoreReceipt.podspec
@@ -21,10 +21,10 @@ Missing from this project:
 Apple's root certificate. This may be obtained from http://www.apple.com/certificateauthority/
 Any measures to make your app cracker proof.
                        DESC
-  s.homepage         = "https://github.com/maciekish/VerifyStoreReceiptiOS"
+  s.homepage         = "https://github.com/bsarr/VerifyStoreReceipt"
   s.license          = 'MIT'
   s.author           = { "Maciej Swic (Only Pod)" => "maciej@swic.name" }
-  s.source           = { :git => "https://github.com/maciekish/VerifyStoreReceipt.git", :tag => "1.0.1" }
+  s.source           = { :git => "git@github.com:bsarr/VerifyStoreReceipt.git", :tag => "1.0.2" }
 
   s.platform     = :ios, '7.0'
   s.requires_arc = true
@@ -33,5 +33,5 @@ Any measures to make your app cracker proof.
 
   s.public_header_files = 'Pod/Classes/*.h'
   s.frameworks = 'StoreKit', 'Security'
-  s.dependency 'OpenSSL-Universal', '1.0.1.j'
+  s.dependency 'OpenSSL-Universal', '1.0.1.l'
 end


### PR DESCRIPTION
Update OpenSSL-Universal version to try to fix compilation errors on VerifyStoreReceipt pod.
